### PR TITLE
Fix skhd-zig macOS dependency syntax

### DIFF
--- a/Casks/skhd-zig.rb
+++ b/Casks/skhd-zig.rb
@@ -12,7 +12,7 @@ cask "skhd-zig" do
   homepage "https://github.com/jackielii/skhd.zig"
 
   # Intel builds are cross-compiled from the arm64 runner (see release.yml).
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "skhd.app"
   # The CLI lives inside the bundle; surface it on PATH so `skhd ...` works


### PR DESCRIPTION
Updates the skhd-zig cask to use Homebrew's current macOS dependency syntax.

This removes the deprecation warning:

```
Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
```

Verification:
- `brew style --fix Casks/skhd-zig.rb`
- Loaded the updated cask with `Cask::CaskLoader.load`